### PR TITLE
Change BHMF h-conversion in the x-axis to 0 (instead of unknown)

### DIFF
--- a/astrodatapy/number_density.py
+++ b/astrodatapy/number_density.py
@@ -278,7 +278,7 @@ class number_density:
             if not self.quiet:
                 print("Converting x axis from h=%.3f to h=%.3f with a power of -5 because it is %s"%(h_obs,self.h, self.feature))
             data[:,0] -= 5 * np.log10(self.h/h_obs)
-        elif self.feature in ['SFRF',]:
+        elif self.feature in ['SFRF','BHMF']:
             if not self.quiet:
                 print("Converting x axis from h=%.3f to h=%.3f with a power of 0 because it is %s"%(h_obs,self.h, self.feature))
         else:


### PR DESCRIPTION
In the Graham+07, Vika+09, Davis+14, and Mutlu-Pakdil+16 BHMF papers, they plot BHMFs that have a h^3 in the y-axis label, but no h in the x-axis label. So I think there is no h conversion required for the x-axis of the BHMF.