### PR TITLE
Fixes for errors with newer astropy version and deprecation warnings from pandas

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -4,7 +4,7 @@ channels:
     - astropy
 
 dependencies:
-    - astropy
+    - astropy<=5.3.4 
     - Cython
     - matplotlib
     - numpy

--- a/README.rst
+++ b/README.rst
@@ -88,9 +88,9 @@ plot galaxy stellar mass function at redshift 5 and show labels
     >>> k_func = 0
     >>> fig, ax = plt.subplots(1, 1)
     >>> for ii in range(obs.n_target_observation):
-    >>>     data       = obs.target_observation['Data'][ii]
+    >>>     data       = obs.target_observation['Data'].iloc[ii]
     >>>     label      = obs.target_observation.index[ii]
-    >>>     datatype   = obs.target_observation['DataType'][ii]
+    >>>     datatype   = obs.target_observation['DataType'].iloc[ii]
     >>>     color      = colors[ii]
     >>>     marker     = markers[j_data]
     >>>     linestyle  = linestyles[k_func]

--- a/astrodatapy/number_density.py
+++ b/astrodatapy/number_density.py
@@ -74,7 +74,7 @@ class number_density:
     
     def _load_info(self):
         info = pd.read_csv(self.folder + self.feature + '/info.txt', keep_default_na=False,\
-                         delim_whitespace=True, skiprows=self.info_skiprows, engine='python')
+                        sep='\s+', skiprows=self.info_skiprows, engine='python')
         info.set_index('#Name', inplace=True)
         self.n_available_observation = len(info.index.values)
         if self.n_available_observation == 0:
@@ -128,9 +128,9 @@ class number_density:
                 data = data.reshape([1,-1])
             
             if 'Type' in info.index:
-                self.target_observation['DataType'][ii] = info.Type
+                self.target_observation.loc[ii, 'DataType'] = info.Type
             else:
-                self.target_observation['DataType'][ii] = 'Unknown'
+                self.target_observation.loc[ii, 'DataType'] = 'Unknown'
             results[ii] = self._convert_observational_data(data, info)
             if not self.quiet:
                 print("..done")


### PR DESCRIPTION
- `update_default_config` function deprecated since astropy v6.0.0 so specified older version in dependencies to make it work for now; will have to fix the framework for latest version

- FutureWarning for `delim_whitespace` keyword deprecation

- FutureWarning for chained assignment; behaviour will change in pandas 3.0

- Updated README to reflect [this](https://github.com/qyx268/astrodatapy/commit/028bb89a4da64f0613a34c0522dca62c21e018a2) change